### PR TITLE
Fixing LocalCommand scoping issue.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ python:
   - "2.7"
 install:
   - pip install nose mock docker-py testinfra
-  - pip install -U pytest==2.9.1
+  - pip install pytest
   - python setup.py install
 script:
   - nosetests --nologcapture --cover-package=tocker
-

--- a/README.md
+++ b/README.md
@@ -53,4 +53,3 @@ If you're using `docker-machine`, you can simply run:
 If you're looking to add a new module, please contribute to [testinfra](https://github.com/philpep/testinfra/).
 
 If it's more specific to `Docker`, you can add additional fixtures under `tocker/fixtures.py`. Pull requests are welcome.
-

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ dependencies = [
 
 setup(
     name='tocker',
-    version='0.1',
+    version='0.2',
     packages=['tocker'],
     license='The MIT License (MIT)',
     author='Nam Ngo',

--- a/tocker/fixtures.py
+++ b/tocker/fixtures.py
@@ -3,8 +3,12 @@ import pytest
 from tocker import Builder
 
 
+# Use testinfra to get a handy function to run commands locally
+local_command = testinfra.get_backend('local://').get_module('Command')
+
+
 @pytest.fixture(scope="module")
-def docker(request, LocalCommand):
+def docker(request):
     # Build image and get the right tag
     try:
         tag = request.module.IMAGE_TAG
@@ -28,14 +32,14 @@ def docker(request, LocalCommand):
     # Run a new container
     args = ' '.join(['%s %s' % (k, v) for k, v in run_args.items()])
     docker_command = "docker run -d %s %s" % (args, tag)
-    docker_id = LocalCommand.check_output(docker_command)
+    docker_id = local_command.check_output(docker_command)
     print('Executing: "%s"' % docker_command)
     print('Running container: %s' % docker_id)
 
     def teardown():
         print('\nRemoving container: %s' % docker_id)
-        LocalCommand.check_output("docker kill %s", docker_id)
-        LocalCommand.check_output("docker rm %s", docker_id)
+        local_command.check_output("docker kill %s", docker_id)
+        local_command.check_output("docker rm %s", docker_id)
 
     # At the end of all tests, we destroy the container
     request.addfinalizer(teardown)

--- a/tocker/test.py
+++ b/tocker/test.py
@@ -49,10 +49,6 @@ class TockerTestCase(TestCase):
         builder = Builder(tag='myimage')
         builder.build()
         mock_build.assert_called_with(
-            decode=True, forcerm=True,
-            path='.', rm=True, tag='myimage'
+            path='.', rm=True, forcerm=True,
+            tag='myimage'
         )
-
-
-
-


### PR DESCRIPTION
fixtures.py was using the "module" scope as well as LocalCommand which
is scoped at a different level. As such, this was preventing testinfra
from successfully running test.

Using pointers from https://github.com/infOpen/pytest-ansible-docker/blob/master/pytest_ansible_docker.py
I have fixed the scoping issue, whilst also running docker builds once
per module.